### PR TITLE
make upload work without JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,22 +12,22 @@
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-vercel": "^2.4.2",
-		"@sveltejs/kit": "^1.15.8",
+		"@sveltejs/adapter-vercel": "^2.4.3",
+		"@sveltejs/kit": "^1.15.10",
 		"autoprefixer": "^10.4.14",
 		"postcss": "^8.4.23",
 		"prettier": "^2.8.8",
 		"prettier-plugin-svelte": "^2.10.0",
 		"svelte": "^3.58.0",
 		"svelte-check": "^3.2.0",
-		"tailwindcss": "^3.3.1",
+		"tailwindcss": "^3.3.2",
 		"tslib": "^2.5.0",
 		"typescript": "^5.0.4",
-		"vite": "^4.3.1"
+		"vite": "^4.3.4"
 	},
 	"type": "module",
 	"dependencies": {
-		"@vercel/blob": "^0.3.1",
+		"@vercel/blob": "^0.3.2",
 		"@vercel/postgres": "0.1.0-canary.5",
 		"postgres": "^3.3.4",
 		"svelte-autosize": "^1.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@vercel/blob':
-    specifier: ^0.3.1
-    version: 0.3.1
+    specifier: ^0.3.2
+    version: 0.3.2
   '@vercel/postgres':
     specifier: 0.1.0-canary.5
     version: 0.1.0-canary.5
@@ -16,11 +16,11 @@ dependencies:
 
 devDependencies:
   '@sveltejs/adapter-vercel':
-    specifier: ^2.4.2
-    version: 2.4.2(@sveltejs/kit@1.15.8)
+    specifier: ^2.4.3
+    version: 2.4.3(@sveltejs/kit@1.15.10)
   '@sveltejs/kit':
-    specifier: ^1.15.8
-    version: 1.15.8(svelte@3.58.0)(vite@4.3.1)
+    specifier: ^1.15.10
+    version: 1.15.10(svelte@3.58.0)(vite@4.3.4)
   autoprefixer:
     specifier: ^10.4.14
     version: 10.4.14(postcss@8.4.23)
@@ -40,8 +40,8 @@ devDependencies:
     specifier: ^3.2.0
     version: 3.2.0(postcss@8.4.23)(svelte@3.58.0)
   tailwindcss:
-    specifier: ^3.3.1
-    version: 3.3.1(postcss@8.4.23)
+    specifier: ^3.3.2
+    version: 3.3.2
   tslib:
     specifier: ^2.5.0
     version: 2.5.0
@@ -49,33 +49,20 @@ devDependencies:
     specifier: ^5.0.4
     version: 5.0.4
   vite:
-    specifier: ^4.3.1
-    version: 4.3.1
+    specifier: ^4.3.4
+    version: 4.3.4
 
 packages:
 
-  /@esbuild/android-arm64@0.16.17:
-    resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
+  /@alloc/quick-lru@5.2.0:
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
     dev: true
-    optional: true
 
   /@esbuild/android-arm64@0.17.18:
     resolution: {integrity: sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm@0.16.17:
-    resolution: {integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
@@ -90,15 +77,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.16.17:
-    resolution: {integrity: sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-x64@0.17.18:
     resolution: {integrity: sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==}
     engines: {node: '>=12'}
@@ -108,28 +86,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.16.17:
-    resolution: {integrity: sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/darwin-arm64@0.17.18:
     resolution: {integrity: sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.16.17:
-    resolution: {integrity: sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
@@ -144,28 +104,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.16.17:
-    resolution: {integrity: sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/freebsd-arm64@0.17.18:
     resolution: {integrity: sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.16.17:
-    resolution: {integrity: sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
@@ -180,28 +122,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.16.17:
-    resolution: {integrity: sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-arm64@0.17.18:
     resolution: {integrity: sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.16.17:
-    resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -216,28 +140,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.16.17:
-    resolution: {integrity: sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-ia32@0.17.18:
     resolution: {integrity: sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.16.17:
-    resolution: {integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -252,28 +158,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.16.17:
-    resolution: {integrity: sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-mips64el@0.17.18:
     resolution: {integrity: sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==}
     engines: {node: '>=12'}
     cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.16.17:
-    resolution: {integrity: sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -288,28 +176,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.16.17:
-    resolution: {integrity: sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-riscv64@0.17.18:
     resolution: {integrity: sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.16.17:
-    resolution: {integrity: sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -324,29 +194,11 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.16.17:
-    resolution: {integrity: sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-x64@0.17.18:
     resolution: {integrity: sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.16.17:
-    resolution: {integrity: sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
     requiresBuild: true
     dev: true
     optional: true
@@ -360,29 +212,11 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.16.17:
-    resolution: {integrity: sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/openbsd-x64@0.17.18:
     resolution: {integrity: sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.16.17:
-    resolution: {integrity: sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
     requiresBuild: true
     dev: true
     optional: true
@@ -396,15 +230,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.16.17:
-    resolution: {integrity: sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-arm64@0.17.18:
     resolution: {integrity: sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==}
     engines: {node: '>=12'}
@@ -414,28 +239,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.16.17:
-    resolution: {integrity: sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-ia32@0.17.18:
     resolution: {integrity: sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==}
     engines: {node: '>=12'}
     cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.16.17:
-    resolution: {integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
@@ -496,7 +303,7 @@ packages:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.5.0
-      tar: 6.1.13
+      tar: 6.1.14
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -539,21 +346,21 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@sveltejs/adapter-vercel@2.4.2(@sveltejs/kit@1.15.8):
-    resolution: {integrity: sha512-HxItPKrt9DmSbKw2X4XVRYa4J2ueTEfQr79ijDcI/ZUtQ64d4X3ilUnLpmm1nXMBb1DyxaWJF4o8avwiV4O2Hw==}
+  /@sveltejs/adapter-vercel@2.4.3(@sveltejs/kit@1.15.10):
+    resolution: {integrity: sha512-3k/3udwaioFYdKDAgQcWSByB+KCbtjX+ARonYGCtYE0iuxWLStrESxy3SaU+17XD5Frh8w7tfY8ft4TV3ej3Dg==}
     peerDependencies:
       '@sveltejs/kit': ^1.5.0
     dependencies:
-      '@sveltejs/kit': 1.15.8(svelte@3.58.0)(vite@4.3.1)
+      '@sveltejs/kit': 1.15.10(svelte@3.58.0)(vite@4.3.4)
       '@vercel/nft': 0.22.6
-      esbuild: 0.16.17
+      esbuild: 0.17.18
     transitivePeerDependencies:
       - encoding
       - supports-color
     dev: true
 
-  /@sveltejs/kit@1.15.8(svelte@3.58.0)(vite@4.3.1):
-    resolution: {integrity: sha512-xPIF3UbFEA5BBZWFTGGUtSZ0O3DAtmzIp/yZZVdLIfzZ9+geKG3iGSVFnOUdYstjU7JcvJg12UC5MD5xoED59A==}
+  /@sveltejs/kit@1.15.10(svelte@3.58.0)(vite@4.3.4):
+    resolution: {integrity: sha512-qRZxODfsixjgY+7OOxhAQB8viVaxjyDUz2lM6cE22kObzF5mNke81FIxB2wdaOX42LyfVwIYULZQSr7duxLZ7w==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     requiresBuild: true
@@ -561,7 +368,7 @@ packages:
       svelte: ^3.54.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.1.0(svelte@3.58.0)(vite@4.3.1)
+      '@sveltejs/vite-plugin-svelte': 2.1.1(svelte@3.58.0)(vite@4.3.4)
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.3.0
@@ -575,13 +382,13 @@ packages:
       svelte: 3.58.0
       tiny-glob: 0.2.9
       undici: 5.22.0
-      vite: 4.3.1
+      vite: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.1.0(svelte@3.58.0)(vite@4.3.1):
-    resolution: {integrity: sha512-Bc9A8mtTGlhTICdLL/aZ+jyHI3kwtkcXremOH5xwjbNNKOTOtY8nMyG8/oZ5KK8IuUfAn1WL58Bp2tofDJBW0w==}
+  /@sveltejs/vite-plugin-svelte@2.1.1(svelte@3.58.0)(vite@4.3.4):
+    resolution: {integrity: sha512-7YeBDt4us0FiIMNsVXxyaP4Hwyn2/v9x3oqStkHU3ZdIc5O22pGwUwH33wUqYo+7Itdmo8zxJ45Qvfm3H7UUjQ==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0
@@ -593,8 +400,8 @@ packages:
       magic-string: 0.30.0
       svelte: 3.58.0
       svelte-hmr: 0.15.1(svelte@3.58.0)
-      vite: 4.3.1
-      vitefu: 0.2.4(vite@4.3.1)
+      vite: 4.3.4
+      vitefu: 0.2.4(vite@4.3.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -607,11 +414,11 @@ packages:
     resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
     dev: true
 
-  /@vercel/blob@0.3.1:
-    resolution: {integrity: sha512-c3wUDhd5Zh1DjpkTooUKez5Ow9cGfHiFDQl1GHQqiKpgQYGLnSbqr8eiKtPhP3um2ptm/Z9on5Pd6QNgtOK1Fg==}
+  /@vercel/blob@0.3.2:
+    resolution: {integrity: sha512-p0/kpUJvyfa40GpCLvIfbJp3wyEUfoaU94ybSpy5Ha8kNsIIvLiLFQeLCdvRqf0/dl4d24ZoeUY4w5ZIg+OYrQ==}
     engines: {node: '>=16.14'}
     dependencies:
-      undici: 5.21.2
+      undici: 5.22.0
     dev: false
 
   /@vercel/nft@0.22.6:
@@ -706,7 +513,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.5
-      caniuse-lite: 1.0.30001481
+      caniuse-lite: 1.0.30001482
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -752,8 +559,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001481
-      electron-to-chromium: 1.4.371
+      caniuse-lite: 1.0.30001482
+      electron-to-chromium: 1.4.380
       node-releases: 2.0.10
       update-browserslist-db: 1.0.11(browserslist@4.21.5)
     dev: true
@@ -778,8 +585,8 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /caniuse-lite@1.0.30001481:
-    resolution: {integrity: sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==}
+  /caniuse-lite@1.0.30001482:
+    resolution: {integrity: sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==}
     dev: true
 
   /chokidar@3.5.3:
@@ -800,10 +607,6 @@ packages:
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
-    dev: true
-
-  /color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
   /color-support@1.1.3:
@@ -878,8 +681,8 @@ packages:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
-  /electron-to-chromium@1.4.371:
-    resolution: {integrity: sha512-jlBzY4tFcJaiUjzhRTCWAqRvTO/fWzjA3Bls0mykzGZ7zvcMP7h05W6UcgzfT9Ca1SW2xyKDOFRyI0pQeRNZGw==}
+  /electron-to-chromium@1.4.380:
+    resolution: {integrity: sha512-XKGdI4pWM78eLH2cbXJHiBnWUwFSzZM7XujsB6stDiGu9AeSqziedP6amNLpJzE3i0rLTcfAwdCTs5ecP5yeSg==}
     dev: true
 
   /emoji-regex@8.0.0:
@@ -888,36 +691,6 @@ packages:
 
   /es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
-    dev: true
-
-  /esbuild@0.16.17:
-    resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.16.17
-      '@esbuild/android-arm64': 0.16.17
-      '@esbuild/android-x64': 0.16.17
-      '@esbuild/darwin-arm64': 0.16.17
-      '@esbuild/darwin-x64': 0.16.17
-      '@esbuild/freebsd-arm64': 0.16.17
-      '@esbuild/freebsd-x64': 0.16.17
-      '@esbuild/linux-arm': 0.16.17
-      '@esbuild/linux-arm64': 0.16.17
-      '@esbuild/linux-ia32': 0.16.17
-      '@esbuild/linux-loong64': 0.16.17
-      '@esbuild/linux-mips64el': 0.16.17
-      '@esbuild/linux-ppc64': 0.16.17
-      '@esbuild/linux-riscv64': 0.16.17
-      '@esbuild/linux-s390x': 0.16.17
-      '@esbuild/linux-x64': 0.16.17
-      '@esbuild/netbsd-x64': 0.16.17
-      '@esbuild/openbsd-x64': 0.16.17
-      '@esbuild/sunos-x64': 0.16.17
-      '@esbuild/win32-arm64': 0.16.17
-      '@esbuild/win32-ia32': 0.16.17
-      '@esbuild/win32-x64': 0.16.17
     dev: true
 
   /esbuild@0.17.18:
@@ -1244,8 +1017,8 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /minipass@4.2.8:
-    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
+  /minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
     dev: true
 
@@ -1397,9 +1170,9 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /postcss-import@14.1.0(postcss@8.4.23):
-    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
-    engines: {node: '>=10.0.0'}
+  /postcss-import@15.1.0(postcss@8.4.23):
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
@@ -1419,9 +1192,9 @@ packages:
       postcss: 8.4.23
     dev: true
 
-  /postcss-load-config@3.1.4(postcss@8.4.23):
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
+  /postcss-load-config@4.0.1(postcss@8.4.23):
+    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
     peerDependencies:
       postcss: '>=8.0.9'
       ts-node: '>=9.0.0'
@@ -1433,21 +1206,21 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.23
-      yaml: 1.10.2
+      yaml: 2.2.2
     dev: true
 
-  /postcss-nested@6.0.0(postcss@8.4.23):
-    resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
+  /postcss-nested@6.0.1(postcss@8.4.23):
+    resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
       postcss: 8.4.23
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.12
     dev: true
 
-  /postcss-selector-parser@6.0.11:
-    resolution: {integrity: sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==}
+  /postcss-selector-parser@6.0.12:
+    resolution: {integrity: sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0
@@ -1489,11 +1262,6 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
-
-  /quick-lru@5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
     dev: true
 
   /read-cache@1.0.0:
@@ -1556,8 +1324,8 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup@3.21.0:
-    resolution: {integrity: sha512-ANPhVcyeHvYdQMUyCbczy33nbLzI7RzrBje4uvNiTDJGIMtlKoOStmympwr9OtS1LZxiDmE2wvxHyVhoLtf1KQ==}
+  /rollup@3.21.3:
+    resolution: {integrity: sha512-VnPfEG51nIv2xPLnZaekkuN06q9ZbnyDcLkaBdJa/W7UddyhOfMP2yOPziYQfeY7k++fZM8FdQIummFN5y14kA==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -1786,16 +1554,14 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /tailwindcss@3.3.1(postcss@8.4.23):
-    resolution: {integrity: sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==}
-    engines: {node: '>=12.13.0'}
+  /tailwindcss@3.3.2:
+    resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
+      '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
       chokidar: 3.5.3
-      color-name: 1.1.4
       didyoumean: 1.2.2
       dlv: 1.1.3
       fast-glob: 3.2.12
@@ -1808,26 +1574,25 @@ packages:
       object-hash: 3.0.0
       picocolors: 1.0.0
       postcss: 8.4.23
-      postcss-import: 14.1.0(postcss@8.4.23)
+      postcss-import: 15.1.0(postcss@8.4.23)
       postcss-js: 4.0.1(postcss@8.4.23)
-      postcss-load-config: 3.1.4(postcss@8.4.23)
-      postcss-nested: 6.0.0(postcss@8.4.23)
-      postcss-selector-parser: 6.0.11
+      postcss-load-config: 4.0.1(postcss@8.4.23)
+      postcss-nested: 6.0.1(postcss@8.4.23)
+      postcss-selector-parser: 6.0.12
       postcss-value-parser: 4.2.0
-      quick-lru: 5.1.1
       resolve: 1.22.2
       sucrase: 3.32.0
     transitivePeerDependencies:
       - ts-node
     dev: true
 
-  /tar@6.1.13:
-    resolution: {integrity: sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==}
+  /tar@6.1.14:
+    resolution: {integrity: sha512-piERznXu0U7/pW7cdSn7hjqySIVTYT6F76icmFk7ptU7dDYlXTm5r9A6K04R2vU3olYgoKeo1Cg3eeu5nhftAw==}
     engines: {node: '>=10'}
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0
-      minipass: 4.2.8
+      minipass: 5.0.0
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
@@ -1883,19 +1648,11 @@ packages:
     hasBin: true
     dev: true
 
-  /undici@5.21.2:
-    resolution: {integrity: sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==}
-    engines: {node: '>=12.18'}
-    dependencies:
-      busboy: 1.6.0
-    dev: false
-
   /undici@5.22.0:
     resolution: {integrity: sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==}
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
-    dev: true
 
   /update-browserslist-db@1.0.11(browserslist@4.21.5):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
@@ -1912,8 +1669,8 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /vite@4.3.1:
-    resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}
+  /vite@4.3.4:
+    resolution: {integrity: sha512-f90aqGBoxSFxWph2b39ae2uHAxm5jFBBdnfueNxZAT1FTpM13ccFQExCaKbR2xFW5atowjleRniQ7onjJ22QEg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -1939,12 +1696,12 @@ packages:
     dependencies:
       esbuild: 0.17.18
       postcss: 8.4.23
-      rollup: 3.21.0
+      rollup: 3.21.3
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vitefu@0.2.4(vite@4.3.1):
+  /vitefu@0.2.4(vite@4.3.4):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
@@ -1952,7 +1709,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.3.1
+      vite: 4.3.4
     dev: true
 
   /webidl-conversions@3.0.1:
@@ -1980,7 +1737,7 @@ packages:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
-  /yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
+  /yaml@2.2.2:
+    resolution: {integrity: sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==}
+    engines: {node: '>= 14'}
     dev: true

--- a/postgres/migrations/001.sql
+++ b/postgres/migrations/001.sql
@@ -29,7 +29,8 @@ CREATE TABLE photo (
 	url TEXT NOT NULL,
 	width INTEGER NOT NULL,
 	height INTEGER NOT NULL,
-	description TEXT NOT NULL
+	description TEXT NOT NULL,
+	published boolean NOT NULL DEFAULT false
 );
 
 CREATE TABLE comment (

--- a/src/lib/components/Uploader.svelte
+++ b/src/lib/components/Uploader.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 
 	let file: File | undefined;
-	let description = '';
 	let pending = false;
 
 	let show = false;
-	let width = 0;
-	let height = 0;
 
 	$: src = file ? URL.createObjectURL(file) : undefined;
 </script>
@@ -25,9 +23,10 @@
 />
 
 <form
-	class="relative w-8 h-8"
+	class="relative w-full h-full"
 	method="POST"
 	action="/?/post"
+	enctype="multipart/form-data"
 	use:enhance={() => {
 		pending = true;
 
@@ -51,7 +50,7 @@
 >
 	<!-- svelte-ignore a11y-click-events-have-key-events-->
 	<div
-		class="fixed w-screen h-screen bg-[#ffffff88] backdrop-blur-lg backdrop-grayscale-50 top-0 left-0 flex justify-center items-center"
+		class="fixed w-screen h-screen bg-[#ffffff88] backdrop-blur-lg backdrop-grayscale-50 top-0 left-0 flex justify-center items-center z-10"
 		class:hidden={!show}
 		on:click={(e) => {
 			if (show && e.target === e.currentTarget) {
@@ -61,32 +60,21 @@
 	>
 		<div class="w-screen height-screen max-w-2xl max-h-[144rem] p-8">
 			<div class="flex flex-col bg-white shadow-xl p-8 w-sc rounded-md">
-				<img
-					class="flex-1 mb-4 object-contain"
-					alt="Preview"
-					{src}
-					on:load={(e) => {
-						width = e.currentTarget.naturalWidth;
-						height = e.currentTarget.naturalHeight;
-					}}
-				/>
-
-				<input type="hidden" name="width" value={width} />
-				<input type="hidden" name="height" value={height} />
+				<img class="flex-1 mb-4 object-contain" alt="Preview" {src} />
 
 				<div class="relative flex w-full border-b border-slate-200 focus-within:border-pink-600">
 					<input
 						class="w-full border-b border-slate-200 resize-none p-2 pr-20 focus-visible:outline-none"
 						name="description"
+						autocomplete="off"
+						spellcheck="false"
 						placeholder="enter a description"
-						required
-						bind:value={description}
+						required={browser}
 					/>
 
 					<button
 						disabled={pending}
-						class="absolute w-16 h-full right-0 transition-opacity text-pink-600 focus-visible:outline-none focus-visible:bg-pink-100"
-						class:opacity-0={!description}
+						class="absolute w-16 h-full right-0 transition-opacity text-pink-600 focus-visible:outline-none focus-visible:bg-pink-100 opacity-0"
 					>
 						upload
 					</button>
@@ -95,12 +83,13 @@
 		</div>
 	</div>
 
-	<label class="absolute left-0 top-0 w-8 h-8 bg-no-repeat">
+	<label class="absolute left-0 top-0 w-full h-full bg-no-repeat">
 		<input
 			class="hidden"
 			type="file"
 			name="file"
 			accept=".jpg,.jpeg,.png"
+			required
 			on:change={(e) => {
 				file = e.currentTarget.files?.[0];
 
@@ -110,11 +99,24 @@
 				}
 			}}
 		/>
+
+		<button class="hidden bg-white w-full h-full">upload</button>
 	</label>
 </form>
 
 <style>
 	label {
 		background-image: url($lib/icons/camera-plus.svg);
+		background-size: 2rem 2rem;
+		background-position: 50% 50%;
+	}
+
+	/* in browsers without JS, the upload button is visible when the file input is populated */
+	label:has(input[type='file']:valid) button {
+		display: block;
+	}
+
+	input[name='description']:valid + button {
+		opacity: 1;
 	}
 </style>

--- a/src/lib/image-size/index.ts
+++ b/src/lib/image-size/index.ts
@@ -1,0 +1,36 @@
+/*
+Code adapted from https://github.com/image-size/image-size
+Reproduced here under the MIT License
+
+---
+
+The MIT License (MIT)
+
+Copyright © 2017 Aditya Yadav, http://netroy.in
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { png } from './png';
+import { jpg } from './jpg';
+import type { Size } from './types';
+
+const types = {
+	png,
+	jpg,
+	jpeg: jpg
+};
+
+export function get_dimensions(buffer: ArrayBuffer, type: keyof typeof types): Size {
+	const fn = types[type];
+
+	if (!fn) {
+		throw new TypeError(`Unsupported image format ${type}`);
+	}
+
+	return fn(buffer);
+}

--- a/src/lib/image-size/jpg.ts
+++ b/src/lib/image-size/jpg.ts
@@ -1,0 +1,138 @@
+// NOTE: we only support baseline and progressive JPGs here
+// due to the structure of the loader class, we only get a buffer
+// with a maximum size of 4096 bytes. so if the SOF marker is outside
+// if this range we can't detect the file size correctly.
+
+import type { Size } from './types';
+
+const APP1_DATA_SIZE_BYTES = 2;
+const EXIF_HEADER_BYTES = 6;
+
+// Each entry is exactly 12 bytes
+const IDF_ENTRY_BYTES = 12;
+const NUM_DIRECTORY_ENTRIES_BYTES = 2;
+
+function is_exif(view: DataView, p: number): boolean {
+	return view.getUint16(p + 2) === 0x4578 && view.getUint16(p + 4) === 0x6966;
+}
+
+function extract_orientation(
+	view: DataView,
+	exif_start: number,
+	exif_end: number,
+	is_little_endian: boolean
+) {
+	// TODO: assert that this contains 0x002A
+	// let STATIC_MOTOROLA_TIFF_HEADER_BYTES = 2
+	// let TIFF_IMAGE_FILE_DIRECTORY_BYTES = 4
+
+	// TODO: derive from TIFF_IMAGE_FILE_DIRECTORY_BYTES
+	const idf_offset = 8;
+
+	// IDF osset works from right after the header bytes
+	// (so the offset includes the tiff byte align)
+	const offset = exif_start + EXIF_HEADER_BYTES + idf_offset;
+
+	const idf_directory_entries = view.getUint16(offset, is_little_endian);
+
+	for (
+		let directory_entry_number = 0;
+		directory_entry_number < idf_directory_entries;
+		directory_entry_number++
+	) {
+		const start = offset + NUM_DIRECTORY_ENTRIES_BYTES + directory_entry_number * IDF_ENTRY_BYTES;
+
+		// Skip on corrupt EXIF blocks
+		if (start > exif_end) {
+			return;
+		}
+
+		const tag_number = view.getUint16(start + 0, is_little_endian);
+
+		// 0x0112 (decimal: 274) is the `orientation` tag ID
+		if (tag_number === 274) {
+			const data_format = view.getUint16(start + 2, is_little_endian);
+
+			if (data_format !== 3) {
+				return;
+			}
+
+			// unsinged int has 2 bytes per component
+			// if there would more than 4 bytes in total it's a pointer
+			const number_of_components = view.getUint32(start + 4, is_little_endian);
+			if (number_of_components !== 1) {
+				return;
+			}
+
+			return view.getUint16(start + 8, is_little_endian);
+		}
+	}
+}
+
+function validate_exif_block(view: DataView, p: number, index: number) {
+	// Skip APP1 Data Size
+	const exif_start = p + APP1_DATA_SIZE_BYTES;
+	const exif_end = p + index;
+
+	// Ignore Empty EXIF. Validate byte alignment
+	const byte1 = view.getUint8(exif_start + 6);
+	const byte2 = view.getUint8(exif_start + 7);
+	const is_big_endian = byte1 === 0x4d && byte2 === 0x4f;
+	const is_little_endian = byte1 === 0x49 && byte2 === 0x49;
+
+	if (is_big_endian || is_little_endian) {
+		return extract_orientation(view, exif_start, exif_end, is_little_endian);
+	}
+}
+
+export function jpg(data: ArrayBuffer): Size {
+	const bytes = new Uint8Array(data);
+
+	if (bytes[0] === 0xff && bytes[1] === 0xd8) {
+		const view = new DataView(data);
+
+		// Skip 4 bytes, they are for signature
+		let p = 4;
+
+		let orientation: number | undefined;
+
+		while (p < bytes.length) {
+			// read length of the next block
+			const i = view.getUint16(p, false);
+
+			if (is_exif(view, p)) {
+				orientation = validate_exif_block(view, p, i);
+			}
+
+			// index should be within buffer limits
+			if (p + i > bytes.length) {
+				throw new TypeError('Corrupt JPG, exceeded buffer limits');
+			}
+
+			// Every JPEG block must begin with a 0xFF
+			if (bytes[p + i] !== 0xff) {
+				throw new TypeError('Invalid JPG, marker table corrupted');
+			}
+
+			// 0xFFC0 is baseline standard(SOF)
+			// 0xFFC1 is baseline optimized(SOF)
+			// 0xFFC2 is progressive(SOF2)
+			const next = bytes[p + i + 1];
+
+			if (next === 0xc0 || next === 0xc1 || next === 0xc2) {
+				const size = {
+					width: view.getUint16(p + i + 7, false),
+					height: view.getUint16(p + i + 5, false)
+				};
+
+				// TODO do we need to swap width and height if orientation is 1?
+				return size;
+			}
+
+			// move to the next block
+			p += i + 2;
+		}
+
+		throw new TypeError('Invalid JPG, no size found');
+	}
+}

--- a/src/lib/image-size/png.ts
+++ b/src/lib/image-size/png.ts
@@ -1,0 +1,31 @@
+import type { Size } from './types';
+
+const decoder = new TextDecoder();
+
+export function png(data: ArrayBuffer): Size {
+	const bytes = new Uint8Array(data);
+
+	if (decoder.decode(bytes.slice(1, 8)) === 'PNG\r\n\x1a\n') {
+		const view = new DataView(data);
+		let str = decoder.decode(bytes.slice(12, 16));
+
+		// handle 'fried' PNGs https://github.com/esjeon/pngdefry
+		if (str === 'CgBI') {
+			if (decoder.decode(bytes.slice(28, 32)) === 'IHDR') {
+				return {
+					height: view.getUint32(36, false),
+					width: view.getUint32(32, false)
+				};
+			}
+		}
+
+		if (str === 'IHDR') {
+			return {
+				height: view.getUint32(20, false),
+				width: view.getUint32(16, false)
+			};
+		}
+	}
+
+	throw new TypeError('Invalid PNG');
+}

--- a/src/lib/image-size/types.d.ts
+++ b/src/lib/image-size/types.d.ts
@@ -1,0 +1,4 @@
+export interface Size {
+	width: number;
+	height: number;
+}

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -1,61 +1,6 @@
 import { POSTGRES_URL } from '$env/static/private';
-import type { PhotoDetails } from '$lib/types';
-import type { Account, Comment, Photo } from '$lib/types';
 import postgres from 'postgres';
 
 export const sql = postgres(POSTGRES_URL, {
 	ssl: 'require'
 });
-
-export async function get_photo_details(account_name: string, photo_id: string) {
-	const [photo] = await sql`
-		SELECT p.*, a.name, a.avatar
-		FROM photo p
-		INNER JOIN account a ON p.account_id = a.id
-		WHERE p.id = ${photo_id}
-		AND a.name = ${account_name}
-	`;
-
-	const comments = await sql`
-		SELECT c.*, a.name, a.avatar
-		FROM comment c
-		INNER JOIN account a ON c.account_id = a.id
-		WHERE c.photo_id = ${photo_id}
-		ORDER BY c.created_at DESC
-	`;
-
-	const likes = await sql`
-		SELECT a.name, a.avatar
-		FROM likes l
-		INNER JOIN account a ON l.account_id = a.id
-		WHERE l.photo_id = ${photo_id}
-		ORDER BY l.created_at DESC
-	`;
-
-	return {
-		photo: photo as PhotoDetails,
-		comments: Array.from(comments) as Comment[],
-		likes: Array.from(likes) as Account[]
-	};
-}
-
-export async function create_photo(
-	account_id: string,
-	url: string,
-	width: number,
-	height: number,
-	description: string
-) {
-	const rows = await sql`
-		INSERT INTO photo (account_id, url, width, height, description)
-		VALUES (${account_id}, ${url}, ${width}, ${height}, ${description})
-		RETURNING id
-	`;
-
-	const photo = rows[0];
-
-	return {
-		...photo,
-		likes: 0
-	} as Photo;
-}

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -17,6 +17,7 @@ export interface Photo {
 	height: number;
 	description: string;
 	likes: number;
+	published: boolean;
 }
 
 export interface PhotoDetails extends Photo {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,7 +33,7 @@
 
 {#if data.user}
 	<footer
-		class="fixed bottom-0 w-full h-16 flex justify-center items-center p-4 border-t bg-white z-10"
+		class="fixed bottom-0 w-full h-16 flex justify-center items-center border-t bg-white z-10"
 	>
 		<Uploader />
 	</footer>

--- a/src/routes/[account]/[photo]/+page.svelte
+++ b/src/routes/[account]/[photo]/+page.svelte
@@ -27,10 +27,10 @@
 	{/if}
 </div>
 
-<figure class="mb-4">
+<div class="mb-4">
 	<Image photo={data.photo} />
-	<figcaption class="mt-4">{data.photo.description}</figcaption>
-</figure>
+	<p class="mt-4">{data.photo.description}</p>
+</div>
 
 <div class="flex items-center mb-8 gap-2">
 	{#if data.user}
@@ -111,8 +111,7 @@
 
 		<button
 			disabled={pending}
-			class="absolute w-16 h-full right-0 transition-opacity text-pink-600 focus-visible:outline-none focus-visible:bg-pink-100"
-			class:opacity-0={!comment}
+			class="absolute w-16 h-full right-0 transition-opacity text-pink-600 focus-visible:outline-none focus-visible:bg-pink-100 opacity-0"
 		>
 			post
 		</button>
@@ -154,5 +153,9 @@
 
 	[aria-label='delete'] {
 		background-image: url($lib/icons/trash.svg);
+	}
+
+	textarea:valid + button {
+		opacity: 1;
 	}
 </style>

--- a/src/routes/api/photos/[account_id].json/+server.ts
+++ b/src/routes/api/photos/[account_id].json/+server.ts
@@ -26,6 +26,7 @@ export async function GET({ locals, params, url }) {
 		) c ON p.id = c.photo_id
 		LEFT JOIN likes ul ON p.id = ul.photo_id AND ul.account_id = ${locals.user?.id ?? null}
 		WHERE p.account_id = ${params.account_id}
+		AND p.published = TRUE
 		AND p.created_at < ${start}
 		ORDER BY p.created_at DESC
 		LIMIT ${PAGE_SIZE + 1};

--- a/src/routes/api/photos/feed.json/+server.ts
+++ b/src/routes/api/photos/feed.json/+server.ts
@@ -35,6 +35,7 @@ export async function GET({ locals, url }) {
 			WHERE account_id = ${locals.user.id}
 		)
 		OR p.account_id = ${locals.user.id})
+		AND p.published = TRUE
 		AND p.created_at < ${start}
 		ORDER BY p.created_at DESC
 		LIMIT ${PAGE_SIZE + 1};

--- a/src/routes/auth/+page.server.ts
+++ b/src/routes/auth/+page.server.ts
@@ -16,7 +16,7 @@ export const actions = {
 		auth.searchParams.set('redirect_uri', `${url.origin}/auth/callback`);
 		auth.searchParams.set('state', state);
 
-		throw redirect(307, auth.href);
+		throw redirect(303, auth.href);
 	},
 
 	logout: async ({ cookies, locals }) => {

--- a/src/routes/publish/+page.server.ts
+++ b/src/routes/publish/+page.server.ts
@@ -1,0 +1,62 @@
+import { sql } from '$lib/server/database.js';
+import type { PhotoDetails } from '$lib/types.js';
+import { error, redirect } from '@sveltejs/kit';
+
+export async function load({ locals, params, url }) {
+	if (!locals.user) {
+		throw error(401);
+	}
+
+	const photo_id = url.searchParams.get('id');
+
+	if (!photo_id) {
+		throw error(400);
+	}
+
+	const [photo] = await sql`
+		SELECT p.*, a.name, a.avatar
+		FROM photo p
+		INNER JOIN account a ON p.account_id = a.id
+		WHERE p.id = ${photo_id}
+		AND p.account_id = ${locals.user.id}
+	`;
+
+	if (!photo) {
+		throw error(404);
+	}
+
+	if (photo.published) {
+		throw redirect(307, `/${locals.user.name}/${photo.id}`);
+	}
+
+	return {
+		photo: photo as PhotoDetails
+	};
+}
+
+export const actions = {
+	default: async ({ locals, request, url }) => {
+		if (!locals.user) throw error(401);
+
+		const photo_id = url.searchParams.get('id');
+		if (!photo_id) throw error(400);
+
+		const data = await request.formData();
+
+		const description = data.get('description') as string;
+		if (!description) throw error(422);
+
+		const [row] = await sql`
+			UPDATE photo
+			SET description = ${description}, published = TRUE
+			WHERE id = ${photo_id}
+			AND account_id = ${locals.user.id}
+			RETURNING id
+		`;
+
+		// if no update was possible, it's because the photo doesn't belong to the user
+		if (!row) throw error(403);
+
+		throw redirect(303, `/${locals.user.name}/${photo_id}`);
+	}
+};

--- a/src/routes/publish/+page.svelte
+++ b/src/routes/publish/+page.svelte
@@ -1,0 +1,52 @@
+<script>
+	import { enhance } from '$app/forms';
+	import Image from '$lib/components/Image.svelte';
+
+	export let data;
+
+	let description = '';
+	let pending = false;
+</script>
+
+<div class="max-w-2xl mt-12 px-4 mx-auto">
+	<h1 class="text-4xl mt-8 mb-4">publish your photo</h1>
+
+	<form
+		class="my-4"
+		method="POST"
+		use:enhance={() => {
+			pending = true;
+			return async ({ update }) => {
+				await update();
+				pending = false;
+			};
+		}}
+	>
+		<div class="relative flex w-full border-b border-slate-200 focus-within:border-pink-600">
+			<input
+				class="w-full border-b border-slate-200 resize-none py-2 pr-20 focus-visible:outline-none"
+				name="description"
+				required
+				autocomplete="off"
+				spellcheck="false"
+				placeholder="add a description"
+				bind:value={description}
+			/>
+
+			<button
+				disabled={pending}
+				class="absolute w-16 h-full right-0 transition-opacity text-pink-600 focus-visible:outline-none focus-visible:bg-pink-100 opacity-0"
+			>
+				publish
+			</button>
+		</div>
+	</form>
+
+	<Image photo={data.photo} />
+</div>
+
+<style>
+	input:valid + button {
+		opacity: 1;
+	}
+</style>


### PR DESCRIPTION
This makes it possible to upload photos in browsers without JS, by splitting it into two steps. Selecting an image causes the 'upload' button to appear; clicking it takes you to `/publish?id=<id>` where you can finalise the upload (i.e. add a description).

Notable changes required to make this work:

* images now have a `published` column, which initialises to `true` if a description was provided (i.e. it came from a JS submission) and `false` otherwise
* image size is detected on the server, using code adapted from the `image-size` package, rather than being done in the browser